### PR TITLE
Electron

### DIFF
--- a/electron-1/main.js
+++ b/electron-1/main.js
@@ -1,5 +1,6 @@
 // Modules to control application life and create native browser window
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path')
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -15,10 +16,14 @@ function createWindow() {
       // ------
       // You are not allowed to change the value
       // of this 3 flags
+      // ok
       nodeIntegration: false,
       enableRemoteModule: false,
-      additionalArguments: []
+      additionalArguments: [],
       // ------
+
+      // found path.join here https://github.com/electron/electron/issues/4459
+      preload: path.join(__dirname, 'preload.js')
     },
   });
 
@@ -57,3 +62,10 @@ app.on('activate', function () {
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+
+ipcMain.on('gibs name', event => {
+  event.sender.send('name', app.getName());
+});
+ipcMain.on('gibs version', event => {
+  event.sender.send('version', app.getVersion());
+});

--- a/electron-1/package-lock.json
+++ b/electron-1/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "electron-quick-start",
+  "name": "electron-1",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/electron-1/preload.js
+++ b/electron-1/preload.js
@@ -1,0 +1,21 @@
+const { app } = require('electron');
+const ipc = require('electron').ipcRenderer;
+
+window.bx = {
+    getName() {
+        return new Promise(function(resolve, reject) {
+            ipc.send('gibs name');
+            ipc.on('name', (stuff, name) => {
+                resolve(name);
+            });
+        });
+    },
+    getVersion() {
+        return new Promise(function(resolve, reject) {
+            ipc.send('gibs version');
+            ipc.on('version', (stuff, version) => {
+                resolve(version);
+            });
+        });
+    },
+}


### PR DESCRIPTION
 - Create BX API - 50min

## Test instructions and expectations

> npm start

## How does it work?

Basicaly I scrolled this : https://zestedesavoir.com/tutoriels/996/vos-applications-avec-electron/ and wandered on official docs too.

At one point I found this part https://electronjs.org/docs/api/browser-window > webPreferences > preload. I liked how it said it could use the API we should not enable anyway.

The tutorial helped me with the communication bit.

the preload script has acces to window and to the ipc api.
it uses the ipc api to send an event to the main and to listen to the response event

the main listens to the events from the preload and answers with the informations.

### Alternatives

There must be some, but I don't know them.

## Critical analysis

### General feeling

Well I felt like I played the Sorcerer's Apprentice, I feel like my solution is more of a hack than anything and I have no clue if it is the good/nice way to do it. It does not seem so.

Whereas I really liked the rxjs test, this felt more cumbersome as scrolling through documentation in look of something that would connect was long and did not feel very smart.

### Difficulties

I felt lost at first, but slowly I started to understand bites and pieces of it.

### Strengths and weaknesses

I have no clue on that.
